### PR TITLE
docs: clarify local video workflow and add file size validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,36 @@ AI-powered tool to automatically extract the best moments from gaming videos usi
 
 Built for **AITX Austin AI Community Hackathon 2025** 🎮
 
+## Quick Start
+
+Get your gaming highlights in 4 easy steps:
+
+1. **Clone the repository**:
+   ```bash
+   git clone https://github.com/atxtechbro/aitx-austin-hackathon-2025.git
+   cd aitx-austin-hackathon-2025
+   ```
+
+2. **Copy the config** (optional - defaults work great):
+   ```bash
+   cp config.example.yml config.yml
+   ```
+
+3. **Drop your video in the project** (won't be committed - see `.gitignore`):
+   ```bash
+   # Just copy your video file here
+   cp ~/Desktop/my_gameplay.mp4 .
+   ```
+
+4. **Open in Claude Code and run**:
+   ```
+   gaming-highlights my_gameplay.mp4
+   ```
+
+**That's it!** Your top 3 highlights will be extracted to `./output/clips/` 🎉
+
+> **Note**: Video files are automatically gitignored and stay local. They're never committed to the repository. To share test videos with contributors, post a cloud link (Google Drive, YouTube) in the issue comments.
+
 ## Features
 
 - 🎮 **Gaming-Focused**: Optimized for detecting action-packed gameplay moments
@@ -64,20 +94,32 @@ Built for **AITX Austin AI Community Hackathon 2025** 🎮
 
 ### Command Examples
 
-- Extract top 3 clips (default):
-  ```
-  gaming-highlights my_gameplay.mp4
-  ```
+**Basic usage** - video in project root:
+```
+gaming-highlights my_apex_gameplay.mp4
+```
 
-- Extract top 5 clips:
-  ```
-  gaming-highlights my_gameplay.mp4 --count 5
-  ```
+**Extract more clips** - get top 5 instead of default 3:
+```
+gaming-highlights my_gameplay.mp4 --count 5
+```
 
-- Preview what would happen (dry-run):
-  ```
-  gaming-highlights my_gameplay.mp4 --dry-run
-  ```
+**Video in subdirectory** (also gitignored):
+```
+gaming-highlights videos/valorant_match.mp4
+```
+
+**Full absolute path** - video outside project:
+```
+gaming-highlights /Users/gamer/Desktop/cod_highlights.mp4
+```
+
+**Preview mode** - see what would happen without processing:
+```
+gaming-highlights my_gameplay.mp4 --dry-run
+```
+
+> **All video formats supported**: `.mp4`, `.mov`, `.mkv`, `.avi`, `.webm`, `.flv`, `.wmv` - they're all gitignored automatically!
 
 ## Output
 

--- a/gaming-highlights.md
+++ b/gaming-highlights.md
@@ -105,8 +105,23 @@ Load settings from config.yml:
 !VIDEO_CLIPS_DIR="${CLIPS_DIR}/${VIDEO_NAME}"
 !VIDEO_METADATA_DIR="${METADATA_DIR}/${VIDEO_NAME}"
 !
-!echo "📹 Processing: $VIDEO_PATH"
+!# Display file size and warnings
+!FILE_SIZE=$(du -h "$VIDEO_PATH" 2>/dev/null | cut -f1)
+!SIZE_BYTES=$(du -b "$VIDEO_PATH" 2>/dev/null | cut -f1)
+!
+!echo "📹 Processing: $VIDEO_PATH ($FILE_SIZE)"
 !echo "Output directory: $VIDEO_CLIPS_DIR"
+!
+!# Warn for large files
+!if [ -n "$SIZE_BYTES" ]; then
+!  if [ "$SIZE_BYTES" -gt 5368709120 ]; then  # > 5GB
+!    echo "⚠️  Very large file detected (5GB+). Processing may take 10+ minutes."
+!    echo "    Consider extracting a shorter segment first for testing."
+!  elif [ "$SIZE_BYTES" -gt 1073741824 ]; then  # > 1GB
+!    echo "⚠️  Large file detected (>1GB). Processing may take several minutes..."
+!  fi
+!fi
+!
 !echo ""
 
 ## Step 2: Setup Output Directories

--- a/videos/README.md
+++ b/videos/README.md
@@ -1,0 +1,37 @@
+# Videos Directory
+
+This directory is for your **local test videos**.
+
+## 📁 How it works
+
+- **Drop videos here**: Place your gaming footage in this directory
+- **Already gitignored**: All video files (`.mp4`, `.mov`, `.mkv`, etc.) are automatically excluded from git
+- **Never committed**: Your videos stay local and private - they're never pushed to GitHub
+- **Any size welcome**: Store 5GB+ files without worrying about repository size
+
+## 🎮 Usage
+
+```bash
+# Place your video in this directory
+cp ~/Desktop/my_gameplay.mp4 videos/
+
+# Run the highlight extractor
+gaming-highlights videos/my_gameplay.mp4
+```
+
+## 🔗 Sharing Test Videos
+
+**Don't commit video files!** Instead, share links in issue comments:
+
+- **Google Drive**: Upload and share a link
+- **YouTube**: Upload as unlisted and share URL
+- **Dropbox/OneDrive**: Share a download link
+
+See `.gitignore` for the complete list of excluded video formats.
+
+## 💡 Pro Tips
+
+- Keep videos here for easy reference
+- Use descriptive filenames: `apex_triple_kill.mp4`, `valorant_clutch_1v4.mp4`
+- Large files (5GB+)? The tool will warn you and suggest extracting shorter segments
+- Test with shorter clips first (1-2 minutes) to iterate faster


### PR DESCRIPTION
## Summary

Clarifies the local video file workflow and adds helpful file size validation to improve the contributor experience. This addresses confusion around whether videos should be checked into git.

## Changes

### 📚 Documentation Updates (README.md)

- **Added Quick Start section**: Prominent 4-step guide showing the simplest path to success
  - Clone → Copy config → Drop video → Run command
  - Explicitly states videos are gitignored and stay local
- **Enhanced Usage examples**: Shows real-world file path patterns
  - Video in project root: `my_gameplay.mp4`
  - Video in subdirectory: `videos/valorant_match.mp4`
  - Full absolute path: `/Users/gamer/Desktop/cod_highlights.mp4`
- **Added note about sharing**: Explains how to share test videos via cloud links instead of checking in files

### 🔧 Code Improvements (gaming-highlights.md)

- **File size detection**: Shows file size for all processed videos
- **Smart warnings**:
  - Files >1GB: "Processing may take several minutes..."
  - Files >5GB: "Processing may take 10+ minutes. Consider extracting a shorter segment first."
- **Better UX**: Users know what to expect before processing starts

### 📁 New: videos/ directory

- Created `videos/README.md` explaining:
  - This directory is for local test videos
  - All video formats are gitignored
  - How to share videos with contributors (cloud links)
  - Pro tips for organizing footage

## Benefits

- ✅ Removes confusion about git workflow (subtraction-creates-value)
- ✅ Better contributor experience (developer-experience)
- ✅ Practical validation helps set expectations
- ✅ Clear examples show real usage patterns

## Testing

Verified that:
- README.md Quick Start is clear and actionable
- File size validation works correctly in gaming-highlights.md
- videos/README.md provides helpful guidance
- All video formats remain gitignored

## Related Issues

Closes #3

Supersedes #2 (cloud URL approach deemed overengineered for MVP)

Related to #1 (contributors should share cloud links, not check in files)