### PR TITLE
feat: add Claude Code slash command support

### DIFF
--- a/.claude/commands/gaming-highlights.md
+++ b/.claude/commands/gaming-highlights.md
@@ -1,0 +1,1 @@
+../../gaming-highlights.md

--- a/README.md
+++ b/README.md
@@ -88,9 +88,19 @@ Get your gaming highlights in 4 easy steps:
 
 ### In Claude Code
 
-1. Open this repository in Claude Code
-2. Say: `"Run gaming-highlights.md on my_gameplay.mp4"`
-3. Claude will execute the procedure and extract your best clips
+**Option 1: Slash Command** (recommended - discoverable in autocomplete):
+```
+/gaming-highlights my_gameplay.mp4
+```
+
+**Option 2: Natural Language**:
+```
+gaming-highlights my_gameplay.mp4
+```
+
+Or simply say: `"Run gaming-highlights.md on my_gameplay.mp4"`
+
+Both methods work identically - use whichever feels more natural!
 
 ### Command Examples
 


### PR DESCRIPTION
## Summary

Adds Claude Code slash command support for the gaming highlights extractor, making it more discoverable and easier to use with autocomplete.

## Changes

### 🔗 New: `.claude/commands/` Structure

- **Created directory**: `.claude/commands/`
- **Added symlink**: `gaming-highlights.md -> ../../gaming-highlights.md`
- **Result**: Users can now invoke with `/gaming-highlights my_gameplay.mp4`

### 📚 Documentation Updates (README.md)

Enhanced the "In Claude Code" section to document both invocation methods:

**Option 1: Slash Command** (recommended):
```
/gaming-highlights my_gameplay.mp4
```

**Option 2: Natural Language**:
```
gaming-highlights my_gameplay.mp4
```

Both work identically - users can choose their preferred style!

## Benefits

✅ **Better discoverability**: Slash commands show up in Claude Code autocomplete  
✅ **Native feel**: Matches Claude Code conventions and UX patterns  
✅ **No duplication**: Symlink maintains single source of truth (systems-stewardship)  
✅ **Consistency**: Follows pattern used in well-structured repos  

## Technical Details

- **Symlink type**: Relative (`../../gaming-highlights.md`)
- **Git tracking**: Symlink is properly tracked (mode 120000)
- **Target verification**: ✓ Target file exists and is accessible

## Testing

Verified that:
- `.claude/commands/gaming-highlights.md` symlink exists
- Symlink points to correct target (`../../gaming-highlights.md`)
- Target file `gaming-highlights.md` exists at repo root
- README documentation is clear and accurate

## Acceptance Criteria

- [x] `.claude/commands/gaming-highlights.md` symlink exists
- [x] Symlink correctly points to `../../gaming-highlights.md`
- [x] README documents both invocation methods
- [x] Symlink is properly tracked in git

## Related Issues

Closes #5

---

**Note**: After merging, users will be able to type `/gam` in Claude Code and see the `/gaming-highlights` command in autocomplete! 🎮